### PR TITLE
Improve aisle matching with fuzzy score cutoff

### DIFF
--- a/data/store_sections.keywords.json
+++ b/data/store_sections.keywords.json
@@ -1,0 +1,10 @@
+{
+  "Produce": ["apple", "apples", "banana", "bananas", "cilantro", "tomato", "tomatoes", "potato", "potatoes", "onion", "onions", "lettuce", "spinach", "carrot", "carrots", "cucumber", "cucumbers", "pepper", "peppers", "broccoli", "garlic", "strawberry", "strawberries", "grape", "grapes", "avocado", "mango", "pear", "peach", "peaches", "orange", "oranges", "grapefruit", "lime", "limes", "lemon", "lemons", "watermelon", "melon"],
+  "Bakery": ["bread", "bagel", "bagels", "roll", "rolls", "cake", "cakes", "cookie", "cookies", "donut", "donuts", "muffin", "muffins", "croissant", "croissants"],
+  "Meat": ["chicken", "beef", "pork", "steak", "turkey", "sausage", "sausages", "bacon", "ham"],
+  "Deli": ["ham", "turkey", "salami", "cheese", "provolone", "swiss", "american cheese", "sandwich", "sub"],
+  "Dairy": ["milk", "cheese", "butter", "yogurt", "cream", "eggs", "egg"],
+  "Frozen": ["frozen", "ice cream", "pizza", "vegetables", "veggies", "fries", "waffles"],
+  "Liquor": ["beer", "wine", "vodka", "whiskey", "rum", "tequila"],
+  "Health & Beauty": ["shampoo", "toothpaste", "soap", "deodorant", "lotion", "cosmetics"]
+}


### PR DESCRIPTION
## Summary
- Add section keyword dataset for high-level areas like Produce and Bakery
- Fall back to matching items against store sections when no aisle keywords match

## Testing
- `pytest`
- `python - <<'PY'
from app.streamlit_app import load_data, best_match
aisles, layout, terms, aisles_for_terms, section_terms, section_names = load_data()

def locate(it):
    a, kw, score = best_match(it, terms, aisles_for_terms)
    if a is None:
        a, kw, score = best_match(it, section_terms, section_names, score_cutoff=60)
    return a, kw, score

for item in ["cilantro", "toilet cleaner", "bagels"]:
    print(item, locate(item))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aa5a4e44e883308bcd5b5a4333f4eb