### PR TITLE
Add navigation mesh generation and routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: nav build run
+
+nav:
+	pipenv run python scripts/rasterize_map.py
+	pipenv run python scripts/build_navmesh.py
+
+build:
+	pipenv run python scripts/parse_waukesha_pdfs_v2.py --debug || true
+	$(MAKE) nav
+
+run:
+	pipenv run streamlit run app/streamlit_app.py

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,10 @@ name = "pypi"
 streamlit = "*"
 rapidfuzz = "*"
 pdfplumber = "*"
+opencv-python = "*"
+numpy = "*"
+pillow = "*"
+pymupdf = "*"
 
 [dev-packages]
 

--- a/app/router.py
+++ b/app/router.py
@@ -1,0 +1,131 @@
+import json
+import math
+import heapq
+import pathlib
+from typing import Dict, List, Tuple
+
+import cv2
+import numpy as np
+from PIL import Image, ImageDraw
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+NAV_JSON_PATH = DATA / "nav.json"
+NAVMASK_PATH = DATA / "navmask.png"
+DIST_CACHE_PATH = DATA / "dist_cache.json"
+
+_NEIGHBORS = [
+    (-1, -1), (0, -1), (1, -1),
+    (-1, 0),          (1, 0),
+    (-1, 1),  (0, 1),  (1, 1),
+]
+
+_nav_data = None
+_nav_mask = None
+_dist_cache: Dict[Tuple[str, str], float] = {}
+
+
+def _load() -> None:
+    global _nav_data, _nav_mask, _dist_cache
+    if _nav_data is not None:
+        return
+    if not NAV_JSON_PATH.exists() or not NAVMASK_PATH.exists():
+        raise FileNotFoundError("Navmesh files not found")
+    with open(NAV_JSON_PATH) as f:
+        _nav_data = json.load(f)
+    _nav_mask = cv2.imread(str(NAVMASK_PATH), cv2.IMREAD_GRAYSCALE)
+    if DIST_CACHE_PATH.exists():
+        with open(DIST_CACHE_PATH) as f:
+            _dist_cache = json.load(f)
+
+
+def _heuristic(a: Tuple[int, int], b: Tuple[int, int]) -> float:
+    return math.hypot(a[0] - b[0], a[1] - b[1])
+
+
+def _astar(start: Tuple[int, int], goal: Tuple[int, int]) -> Tuple[float, List[Tuple[int, int]]]:
+    _load()
+    h, w = _nav_mask.shape
+    start = (int(round(start[0])), int(round(start[1])))
+    goal = (int(round(goal[0])), int(round(goal[1])))
+    open_set = [(0 + _heuristic(start, goal), 0, start)]
+    came: Dict[Tuple[int, int], Tuple[int, int]] = {}
+    gscore = {start: 0}
+    while open_set:
+        _, g, current = heapq.heappop(open_set)
+        if current == goal:
+            path = [current]
+            while current in came:
+                current = came[current]
+                path.append(current)
+            path.reverse()
+            return g, path
+        cx, cy = current
+        for dx, dy in _NEIGHBORS:
+            nx, ny = cx + dx, cy + dy
+            if not (0 <= nx < w and 0 <= ny < h):
+                continue
+            if _nav_mask[ny, nx] == 0:
+                continue
+            step = math.hypot(dx, dy)
+            ng = g + step
+            if ng < gscore.get((nx, ny), float("inf")):
+                gscore[(nx, ny)] = ng
+                came[(nx, ny)] = current
+                f = ng + _heuristic((nx, ny), goal)
+                heapq.heappush(open_set, (f, ng, (nx, ny)))
+    return float("inf"), []
+
+
+def shortest_distance(a_label: str, b_label: str) -> float:
+    _load()
+    key = tuple(sorted([a_label, b_label]))
+    if key in _dist_cache:
+        return _dist_cache[key]
+    stops = _nav_data["stops"]
+    dist, _ = _astar(tuple(stops[a_label]), tuple(stops[b_label]))
+    _dist_cache[key] = dist
+    with open(DIST_CACHE_PATH, "w") as f:
+        json.dump(_dist_cache, f, indent=2)
+    return dist
+
+
+def solve_route(stops: List[str], start: str) -> List[str]:
+    _load()
+    stops = list(dict.fromkeys(stops))
+    if start not in stops:
+        stops.insert(0, start)
+    route = [start]
+    remaining = set(stops) - {start}
+    while remaining:
+        last = route[-1]
+        nxt = min(remaining, key=lambda s: shortest_distance(last, s))
+        route.append(nxt)
+        remaining.remove(nxt)
+    # single 2-opt pass
+    for i in range(1, len(route) - 2):
+        for j in range(i + 1, len(route) - 1):
+            a, b, c, d = route[i - 1], route[i], route[j], route[j + 1]
+            if (
+                shortest_distance(a, b) + shortest_distance(c, d)
+                > shortest_distance(a, c) + shortest_distance(b, d)
+            ):
+                route[i:j + 1] = reversed(route[i:j + 1])
+    return route
+
+
+def render_path(labels: List[str]) -> Image.Image:
+    _load()
+    img = Image.open(_nav_data["image_path"]).convert("RGB")
+    draw = ImageDraw.Draw(img)
+    stops = _nav_data["stops"]
+    for i in range(len(labels) - 1):
+        _, path = _astar(tuple(stops[labels[i]]), tuple(stops[labels[i + 1]]))
+        if path:
+            draw.line(path, fill=(255, 0, 0), width=3)
+    for lab in labels:
+        x, y = stops[lab]
+        r = 4
+        draw.ellipse((x - r, y - r, x + r, y + r), fill=(0, 0, 255))
+        draw.text((x + r + 2, y - r - 2), lab, fill=(0, 0, 0))
+    return img

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,14 +1,20 @@
-import streamlit as st
-from rapidfuzz import process, fuzz
-import json, re, math
+import json
+import math
+import re
 from pathlib import Path
+
+import streamlit as st
+from rapidfuzz import fuzz, process
+from app.router import solve_route, render_path
 
 st.set_page_config(page_title="Woodman's Waukesha Aisle Finder", layout="wide")
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 KEYWORDS_JSON = DATA_DIR / "waukesha_aisles.keywords.json"
-LAYOUT_JSON   = DATA_DIR / "waukesha_layout.json"
-SECTION_JSON  = DATA_DIR / "store_sections.keywords.json"
+LAYOUT_JSON = DATA_DIR / "waukesha_layout.json"
+SECTION_JSON = DATA_DIR / "store_sections.keywords.json"
+NAV_JSON = DATA_DIR / "nav.json"
+NAV_MASK = DATA_DIR / "navmask.png"
 
 @st.cache_data
 def load_data():
@@ -46,36 +52,6 @@ def best_match(item: str, terms, aisles, score_cutoff: int = 75):
     match, score, idx = result
     return aisles[idx], match, int(score)
 
-def order_stops(stops, layout):
-    coords = layout.get("coords") or {}
-    if coords and all(s in coords for s in stops):
-        # nearest-neighbor from a sensible start
-        start = None
-        ro = layout.get("route_order", [])
-        for cand in ["Produce","Bakery"]:
-            if cand in stops and cand in coords:
-                start = cand; break
-        if start is None:
-            for s in ro:
-                if s in stops and s in coords:
-                    start = s; break
-        start = start or stops[0]
-        route = [start]
-        remaining = set(stops) - {start}
-        def dist(a,b):
-            ax,ay = coords[a]; bx,by = coords[b]
-            return math.hypot(ax-bx, ay-by)
-        while remaining:
-            last = route[-1]
-            nxt = min(remaining, key=lambda s: dist(last, s))
-            route.append(nxt)
-            remaining.remove(nxt)
-        return route
-    ro = layout.get("route_order", [])
-    ordered = [s for s in ro if s in stops]
-    tail = [s for s in stops if s not in ordered]
-    return ordered + tail
-
 def main():
     st.title("Woodman's Waukesha Aisle Finder")
 
@@ -85,8 +61,11 @@ def main():
 
     aisles, layout, terms, aisles_for_terms, section_terms, section_names = load_data()
 
-    items_text = st.text_area("Paste your items (one per line):", height=220,
-                              placeholder="bananas\nramen\ncake mix\ncoffee filters\nyogurt")
+    items_text = st.text_area(
+        "Paste your items (one per line):",
+        height=220,
+        placeholder="bananas\nramen\ncake mix\ncoffee filters\nyogurt",
+    )
     items = [ln.strip() for ln in items_text.splitlines() if ln.strip()]
 
     if st.button("Find aisles"):
@@ -103,18 +82,43 @@ def main():
         by_aisle = {}
         for r in rows:
             by_aisle.setdefault(r["Aisle/Area"], []).append(r["Item"])
-        stops = [k for k in by_aisle.keys() if k != "Unknown"]
-        ordered_stops = order_stops(stops, layout)
+        stops = sorted(k for k in by_aisle.keys() if k != "Unknown")
+
+        img = None
+        if NAV_JSON.exists() and NAV_MASK.exists():
+            with open(NAV_JSON) as f:
+                nav = json.load(f)
+            if "Entrance" in nav.get("stops", {}):
+                start = "Entrance"
+            elif "Produce" in nav.get("stops", {}):
+                start = "Produce"
+            else:
+                start = stops[0] if stops else "Entrance"
+            ordered_stops = solve_route(stops, start)
+            img = render_path(ordered_stops)
+        else:
+            st.warning(
+                "Navigation files missing. Run:
+"
+                "pipenv run python scripts/rasterize_map.py
+"
+                "pipenv run python scripts/build_navmesh.py"
+            )
+            ordered_stops = stops
 
         st.subheader("Suggested walking route")
         for s in ordered_stops:
             st.markdown(f"**{s}**: " + ", ".join(by_aisle[s]))
         if "Unknown" in by_aisle:
             st.markdown("**Unknown**: " + ", ".join(by_aisle["Unknown"]))
+        if img is not None:
+            st.image(img)
 
         st.download_button(
             "Download CSV",
-            data="Item,Aisle,Confidence\n" + "\n".join(f"{r['Item']},{r['Aisle/Area']},{r['Confidence']}" for r in rows),
+            data="Item,Aisle,Confidence\n" + "\n".join(
+                f"{r['Item']},{r['Aisle/Area']},{r['Confidence']}" for r in rows
+            ),
             file_name="woodmans_waukesha_list.csv",
             mime="text/csv",
         )

--- a/scripts/build_navmesh.py
+++ b/scripts/build_navmesh.py
@@ -1,0 +1,187 @@
+import json
+import os
+import pathlib
+from typing import List
+
+import cv2
+import numpy as np
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+STORE_IMG = DATA / "store_map.png"
+NAVMASK_IMG = DATA / "navmask.png"
+NAV_JSON = DATA / "nav.json"
+KEYWORDS_JSON = DATA / "waukesha_aisles.keywords.json"
+LAYOUT_JSON = DATA / "waukesha_layout.json"
+
+CANNY_LOW = 50
+CANNY_HIGH = 150
+MORPH_KERNEL = 9
+MIN_COMPONENT_AREA = 500
+PEAK_MIN_DIST = 40
+ENTRANCE_EDGE = os.getenv("ENTRANCE_EDGE", "bottom")  # top|bottom|left|right
+
+
+def load_keywords() -> List[int]:
+    with open(KEYWORDS_JSON) as f:
+        data = json.load(f)
+    ids = sorted(int(k) for k in data.keys() if k.isdigit())
+    return ids
+
+
+def determine_direction(nums: List[int]) -> int:
+    if not LAYOUT_JSON.exists():
+        return 1
+    with open(LAYOUT_JSON) as f:
+        layout = json.load(f)
+    ro = layout.get("route_order", [])
+    first_num = next((int(s) for s in ro if s.isdigit()), nums[0])
+    if first_num == nums[-1]:
+        return -1
+    return 1
+
+
+def preprocess(img: np.ndarray) -> np.ndarray:
+    blur = cv2.GaussianBlur(img, (5, 5), 0)
+    edges = cv2.Canny(blur, CANNY_LOW, CANNY_HIGH)
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (MORPH_KERNEL, MORPH_KERNEL))
+    closed = cv2.morphologyEx(edges, cv2.MORPH_CLOSE, kernel)
+    _, mask = cv2.threshold(closed, 0, 255, cv2.THRESH_BINARY)
+    walkable = cv2.bitwise_not(mask)
+    # remove tiny obstacle specks
+    inv = 255 - walkable
+    n, labels, stats, _ = cv2.connectedComponentsWithStats(inv)
+    for i in range(1, n):
+        if stats[i, cv2.CC_STAT_AREA] < MIN_COMPONENT_AREA:
+            inv[labels == i] = 0
+    walkable = 255 - inv
+    return walkable
+
+
+def find_corridors(mask: np.ndarray, expected: int) -> List[int]:
+    obstacles = (mask == 0).astype(np.uint8)
+    profile = obstacles.sum(axis=0).astype(np.float32)
+    profile = cv2.GaussianBlur(profile, (51, 1), 0)
+    mins = []
+    last = -1e9
+    for x in range(1, profile.shape[0] - 1):
+        if profile[x] < profile[x - 1] and profile[x] < profile[x + 1]:
+            if x - last >= PEAK_MIN_DIST:
+                mins.append(x)
+                last = x
+    if len(mins) != expected:
+        print(
+            f"Warning: expected {expected} corridors, detected {len(mins)}; using even spacing"
+        )
+        mins = np.linspace(0, mask.shape[1] - 1, expected + 2)[1:-1].astype(int).tolist()
+    return mins
+
+
+def column_max(dist: np.ndarray, x: int) -> int:
+    col = dist[:, x]
+    return int(np.argmax(col))
+
+
+def find_edge_point(dist: np.ndarray, mask: np.ndarray, edge: str) -> tuple[int, int]:
+    h, w = mask.shape
+    margin_y = max(1, h // 20)
+    margin_x = max(1, w // 20)
+    best = (-1, -1)
+    bestd = -1.0
+    if edge in ("top", "bottom"):
+        ys = range(0, margin_y) if edge == "top" else range(h - margin_y, h)
+        for y in ys:
+            for x in range(w):
+                if mask[y, x]:
+                    d = dist[y, x]
+                    if d > bestd:
+                        bestd = d
+                        best = (x, y)
+    else:
+        xs = range(0, margin_x) if edge == "left" else range(w - margin_x, w)
+        for x in xs:
+            for y in range(h):
+                if mask[y, x]:
+                    d = dist[y, x]
+                    if d > bestd:
+                        bestd = d
+                        best = (x, y)
+    return best
+
+
+def nearest_walkable(mask: np.ndarray, dist: np.ndarray, x: int, y: int) -> tuple[int, int]:
+    h, w = mask.shape
+    if mask[min(max(y, 0), h - 1), min(max(x, 0), w - 1)]:
+        return (min(max(x, 0), w - 1), min(max(y, 0), h - 1))
+    best = (x, y)
+    bestd = -1.0
+    for r in range(1, 20):
+        for ny in range(max(0, y - r), min(h, y + r + 1)):
+            for nx in range(max(0, x - r), min(w, x + r + 1)):
+                if mask[ny, nx]:
+                    d = dist[ny, nx]
+                    if d > bestd:
+                        bestd = d
+                        best = (nx, ny)
+        if bestd >= 0:
+            break
+    return best
+
+
+def main() -> None:
+    if NAVMASK_IMG.exists() and NAV_JSON.exists():
+        print("Navmesh already built; remove files to rebuild")
+        return
+    if not STORE_IMG.exists():
+        raise SystemExit("Run rasterize_map.py first")
+
+    img = cv2.imread(str(STORE_IMG), cv2.IMREAD_GRAYSCALE)
+    mask = preprocess(img)
+    cv2.imwrite(str(NAVMASK_IMG), mask)
+
+    dist = cv2.distanceTransform(mask, cv2.DIST_L2, 3)
+    aisle_ids = load_keywords()
+    corridors = find_corridors(mask, len(aisle_ids))
+    direction = determine_direction(aisle_ids)
+    ordered_ids = aisle_ids if direction == 1 else list(reversed(aisle_ids))
+    ordered_corridors = corridors if direction == 1 else list(reversed(corridors))
+
+    stops: dict[str, list[int]] = {}
+    for aid, x in zip(ordered_ids, ordered_corridors):
+        y = column_max(dist, x)
+        stops[str(aid)] = [int(x), int(y)]
+
+    entrance = find_edge_point(dist, mask, ENTRANCE_EDGE)
+    stops["Entrance"] = list(entrance)
+    # Departments near entrance edge; tweak manually later if needed
+    prod = nearest_walkable(mask, dist, entrance[0] + 50, entrance[1])
+    stops["Produce"] = list(prod)
+    bak = nearest_walkable(mask, dist, entrance[0] + 100, entrance[1])
+    stops["Bakery"] = list(bak)
+
+    opp_edge = {
+        "top": "bottom",
+        "bottom": "top",
+        "left": "right",
+        "right": "left",
+    }[ENTRANCE_EDGE]
+    frozen = find_edge_point(dist, mask, opp_edge)
+    stops["Frozen"] = list(frozen)
+    dairy = nearest_walkable(mask, dist, frozen[0] + 100, frozen[1])
+    stops["Dairy"] = list(dairy)
+
+    data = {
+        "image_path": str(STORE_IMG),
+        "mask_path": str(NAVMASK_IMG),
+        "pixel_scale": 1.0,
+        "stops": stops,
+        "meta": {"notes": "auto-generated", "version": 1},
+    }
+    NAV_JSON.write_text(json.dumps(data, indent=2))
+
+    print(f"Detected {len(corridors)} corridors -> {len(aisle_ids)} aisles")
+    print(f"Wrote {NAVMASK_IMG} and {NAV_JSON}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rasterize_map.py
+++ b/scripts/rasterize_map.py
@@ -1,0 +1,33 @@
+import os
+import pathlib
+import fitz
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+RAW_PDF = ROOT / "raw_pdfs" / "store-map-13.pdf"
+OUT_IMG = ROOT / "data" / "store_map.png"
+DPI = 250
+
+
+def main() -> None:
+    """Rasterize the store map PDF into a PNG image.
+
+    The PDF may contain multiple pages but we only care about the first one.
+    If the output image already exists the script exits quietly so it can be
+    re-run without side effects.
+    """
+    if OUT_IMG.exists():
+        print(f"{OUT_IMG} already exists, skipping")
+        return
+    if not RAW_PDF.exists():
+        raise SystemExit(f"Missing PDF: {RAW_PDF}")
+
+    OUT_IMG.parent.mkdir(parents=True, exist_ok=True)
+    with fitz.open(RAW_PDF) as doc:
+        page = doc.load_page(0)
+        pix = page.get_pixmap(dpi=DPI)
+        pix.save(OUT_IMG)
+    print(f"Wrote {OUT_IMG}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scripts to rasterize store PDF and build a navigation mesh with aisle stops
- implement A* routing utilities and integrate route overlay into the Streamlit app
- provide Makefile targets for generating nav data and running the app

## Testing
- `pipenv run python scripts/rasterize_map.py`
- `pipenv run python scripts/build_navmesh.py`
- `pipenv run streamlit run app/streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa6a5bf5748330b7bd796c1a3d9bf8